### PR TITLE
Install missing `smbus2` dependency in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/RequestForCoffee/scd30",
     packages=setuptools.find_packages(),
+    install_requires=[
+        "smbus2~=0.3.0"
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hi,

Nice library, worked out of the box :clap: 

Here is a small PR for a missing dependency I noticed.