### PR TITLE
Add missing `import time` in README's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ measurements are stored in a buffer. A "data ready status" command is provided t
 The following example code will begin periodic measurements at a two-second interval and print the readings:
 
 ```py
+import time
 from scd30_i2c import SCD30
 
 scd30 = SCD30()


### PR DESCRIPTION
Missing `import` statement in the example code in the README.